### PR TITLE
Adjust to new awscli Expiration date format.

### DIFF
--- a/awsenv
+++ b/awsenv
@@ -67,7 +67,7 @@ credentials_cache_not_expired() {
   # treat empty cache
   [ -n "$(jq < "$cache")" ] || return 1
 
-  jq --exit-status '(.Credentials.Expiration | fromdate) > now' < "$cache" > /dev/null
+  jq --exit-status '(.Credentials.Expiration | sub("\\+00:00$"; "Z") | fromdate) > now' < "$cache" > /dev/null
 }
 
 credentials_json_or_cache() {


### PR DESCRIPTION
## Problem description

At some point awscli seemed to change its `Expiration` date format returned in `assume-role`.

**■ old version(1.18.57)**
```
$ aws --version
aws-cli/1.18.57 Python/2.7.13 Linux/5.4.0-62-generic botocore/1.16.7

$ aws --output json --profile ${PROFILE} sts assume-role --role-arn ${ROLE_ARN} --role-session-name aws-env-1611213417 --serial-number ${SERIAL_NUMBER} --token-code XXXXXX --duration 43200 | jq '.Credentials.Expiration'
"2021-01-21T19:25:38Z"
```

**■ new version(2.1.19)**
```
❯ aws --version
aws-cli/2.1.19 Python/3.7.3 Linux/5.4.0-62-generic exe/x86_64.ubuntu.20 prompt/off

❯ aws --output json --profile ${PROFILE} sts assume-role --role-arn ${ROLE_ARN} --role-session-name aws-env-1611213417 --serial-number ${SERIAL_NUMBER} --token-code XXXXXX --duration 43200 | jq '.Credentials.Expiration'
"2021-01-21T19:26:24+00:00"
```

## Fix
Since jq `fromdate` still requires the old format, replace new format's `+00:00` to `Z`.

I've confirmed the fix satisfies both new/old formats.

```
❯ jq --null-input '"2021-01-21T19:17:39+00:00" | sub("\\+.*$"; "Z") | fromdate'
1611256659
```
```
❯ jq --null-input '"2021-01-21T19:17:39Z" | sub("\\+.*$"; "Z") | fromdate'
1611256659
```